### PR TITLE
Use fast math for native benchmark

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,7 +40,6 @@ CFLAGS      += -qopt-report-phase$(EQCOLON)vec
 CFLAGS      += -$(QOPT)restrict
 CFLAGS      += -qopenmp
 CFLAGS      += -I./
-CFLAGS		+= -fp-model precise
 
 PREC ?= d
 ifeq ($(PREC),d)
@@ -69,7 +68,7 @@ ifeq ($(TARGET_ARCH),auto)
     CFLAGS += -xCORE-AVX2 -axCOMMON-AVX512
 endif
 
-ACC ?= ha
+ACC ?= ep
 ifeq ($(ACC),ha)
     CFLAGS += -$(FQOPT)imf-precision$(EQCOLON)high -D_VML_ACCURACY_HA_
 endif

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -71,6 +71,7 @@ endif
 ACC ?= ep
 ifeq ($(ACC),ha)
     CFLAGS += -$(FQOPT)imf-precision$(EQCOLON)high -D_VML_ACCURACY_HA_
+    CFLAGS += -fp-model precise
 endif
 ifeq ($(ACC),la)
     CFLAGS += -$(FQOPT)imf-precision$(EQCOLON)medium -D_VML_ACCURACY_LA_


### PR DESCRIPTION
This will make native benchmarks and numba-jit-loop-par versions consistent in both using fast math