### PR TITLE
Fixing performance of numba_numpy by using pre-allocated arrays for result

### DIFF
--- a/bs_erf_numba_numpy.py
+++ b/bs_erf_numba_numpy.py
@@ -15,7 +15,7 @@ def nberf(x):
     return erf(x)
 
 @nb.jit(nopython=True, parallel=True)
-def black_scholes( nopt, price, strike, t, rate, vol ):
+def black_scholes( nopt, price, strike, t, rate, vol, call, put ):
 	mr = -rate
 	sig_sig_two = vol * vol * 2
 
@@ -38,9 +38,8 @@ def black_scholes( nopt, price, strike, t, rate, vol ):
 
 	Se = exp(b) * S
 
-	call = P * d1 - Se * d2
-	put = call - P + Se
+	r =  P * d1 - Se * d2
+	call[:] = r  # temporary `r` is necessary for faster `put` computation
+	put[:] = r - P + Se
 
-	return call, put
-
-base_bs_erf.run("Numba@jit-numpy", black_scholes)
+base_bs_erf.run("Numba@jit-numpy", black_scholes, nparr=True, pass_args=True)

--- a/bs_erf_numpy.py
+++ b/bs_erf_numpy.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy import log, exp
 from base_bs_erf import erf, invsqrt
 
-def black_scholes ( nopt, price, strike, t, rate, vol ):
+def black_scholes ( nopt, price, strike, t, rate, vol, call, put ):
 	mr = -rate
 	sig_sig_two = vol * vol * 2
 
@@ -31,9 +31,8 @@ def black_scholes ( nopt, price, strike, t, rate, vol ):
 
 	Se = exp(b) * S
 
-	call = P * d1 - Se * d2
-	put = call - P + Se
+	call[:] = P * d1 - Se * d2
+	put[:] = call - P + Se
 
-	return (call, put)
 
-base_bs_erf.run("Numpy", black_scholes)
+base_bs_erf.run("Numpy", black_scholes, nparr=True, pass_args=True)


### PR DESCRIPTION
Also aligned numpy version to use pre-allocated arrays though it doesn't change its performance.