### PR TITLE
Add version with fastmath numba.njit annotation

### DIFF
--- a/bs_erf_numba_jit_fastmath.py
+++ b/bs_erf_numba_jit_fastmath.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+
+import base_bs_erf
+import numba as nb
+from math import log, sqrt, exp, erf
+
+@nb.njit(error_model='numpy', fastmath=True)
+def black_scholes( nopt, price, strike, t, rate, vol, call, put):
+    mr = -rate
+    sig_sig_two = vol * vol * 2
+
+    for i in range(nopt):
+        P = price[i]
+        S = strike [i]
+        T = t [i]
+
+        a = log(P / S)
+        b = T * mr
+
+        z = T * sig_sig_two
+        c = 0.25 * z
+        y = 1./sqrt(z)
+
+        w1 = (a - b + c) * y
+        w2 = (a - b - c) * y
+
+        d1 = 0.5 + 0.5 * erf(w1)
+        d2 = 0.5 + 0.5 * erf(w2)
+
+        Se = exp(b) * S
+
+        r  = P * d1 - Se * d2
+        call [i] = r
+        put [i] = r - P + Se
+
+if __name__ == '__main__':
+   base_bs_erf.run("Numba@jit-loop", black_scholes, nparr=True, pass_args=True)

--- a/bs_erf_numba_jit_par_fastmath.py
+++ b/bs_erf_numba_jit_par_fastmath.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2017-2018 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+
+import base_bs_erf
+import numba as nb
+from math import log, sqrt, exp, erf
+
+@nb.njit(error_model='numpy', fastmath=True, parallel=True)
+def black_scholes( nopt, price, strike, t, rate, vol, call, put):
+    mr = -rate
+    sig_sig_two = vol * vol * 2
+
+    for i in nb.prange(nopt):
+        P = price[i]
+        S = strike [i]
+        T = t [i]
+
+        a = log(P / S)
+        b = T * mr
+
+        z = T * sig_sig_two
+        c = 0.25 * z
+        y = 1./sqrt(z)
+
+        w1 = (a - b + c) * y
+        w2 = (a - b - c) * y
+
+        d1 = 0.5 + 0.5 * erf(w1)
+        d2 = 0.5 + 0.5 * erf(w2)
+
+        Se = exp(b) * S
+
+        r  = P * d1 - Se * d2
+        call [i] = r
+        put [i] = r - P + Se
+
+
+if __name__ == '__main__':
+   base_bs_erf.run("Numba@jit-loop-par", black_scholes, nparr=True, pass_args=True)

--- a/main.c
+++ b/main.c
@@ -28,7 +28,7 @@ int main(int argc, char * argv[])
     {
         sscanf(argv[1], "%d", &nopt);
         /* Read steps number of options parameter from command line */
-        if (argc == 3)
+        if (argc > 2)
         {
             sscanf(argv[2], "%d", &steps);
         }

--- a/main.c
+++ b/main.c
@@ -14,6 +14,7 @@
 int main(int argc, char * argv[])
 {
     int nopt = 1 * 1024;
+    int steps = STEPS;
     tfloat *s0, *x, *t, *vcall_mkl, *vput_mkl, *vcall_compiler, *vput_compiler;
 
     clock_t t1 = 0, t2 = 0;
@@ -26,10 +27,15 @@ int main(int argc, char * argv[])
     else
     {
         sscanf(argv[1], "%d", &nopt);
+        /* Read steps number of options parameter from command line */
+        if (argc == 3)
+        {
+            sscanf(argv[2], "%d", &steps);
+        }
     }
 
     int i, j;
-    for(i = 0; i < STEPS; i++) {
+    for(i = 0; i < steps; i++) {
     
         /* Allocate arrays, generate input data */
         InitData( nopt, &s0, &x, &t, &vcall_compiler, &vput_compiler, &vcall_mkl, &vput_mkl );


### PR DESCRIPTION
There are two versions added 
@nb.njit(error_model='numpy', fastmath=True)
@nb.njit(error_model='numpy', fastmath=True, parallel=True)

In addition, in native-c implementation hardcode of STEPS is changed to optional command line argument. If "steps" not provided then hardcoded STEPS is used.